### PR TITLE
Only specify major version for rake/bundler/rspec

### DIFF
--- a/chloride.gemspec
+++ b/chloride.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7.9"
-  spec.add_development_dependency "rake", "~> 11.3"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler", "~> 1"
+  spec.add_development_dependency "rake", "~> 11"
+  spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "simplecov", "~> 0.12"
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "pry-coolline", "~> 0.2"


### PR DESCRIPTION
When testing across ruby versions the available, rake/bundler/rspec
version often varies widely. Most likely we will only encounter
compatibility issues when major releases happen, so that is
all that I am specifying in the gemspec.